### PR TITLE
Improve annotation mode sorting, status updates, and notifications

### DIFF
--- a/R/sample_loading.R
+++ b/R/sample_loading.R
@@ -41,6 +41,17 @@ load_from_csv <- function(csv_path) {
   # This matches iRfcb behavior where class folders may include numeric suffixes
   classifications$class_name <- sub("_\\d{3}$", "", classifications$class_name)
 
+  # Add placeholder dimensions if not present (will be populated later if needed)
+  if (!"width" %in% names(classifications)) {
+    classifications$width <- NA_real_
+  }
+  if (!"height" %in% names(classifications)) {
+    classifications$height <- NA_real_
+  }
+  if (!"roi_area" %in% names(classifications)) {
+    classifications$roi_area <- NA_real_
+  }
+
   classifications
 }
 
@@ -53,7 +64,7 @@ load_from_csv <- function(csv_path) {
 #' @param sample_name Sample name (e.g., "D20230101T120000_IFCB134")
 #' @param class2use Character vector of class names (from class2use file)
 #' @param roi_dimensions Data frame from \code{\link{read_roi_dimensions}}
-#' @return Data frame with columns: file_name, class_name, score, roi_area
+#' @return Data frame with columns: file_name, class_name, score, width, height, roi_area
 #' @export
 #' @examples
 #' \dontrun{
@@ -88,6 +99,8 @@ load_from_mat <- function(mat_path, sample_name, class2use, roi_dimensions) {
     file_name = sprintf("%s_%05d.png", sample_name, roi_numbers),
     class_name = class_names,
     score = NA_real_,
+    width = roi_dimensions$width[roi_numbers],
+    height = roi_dimensions$height[roi_numbers],
     roi_area = roi_dimensions$area[roi_numbers],
     stringsAsFactors = FALSE
   )
@@ -107,7 +120,7 @@ load_from_mat <- function(mat_path, sample_name, class2use, roi_dimensions) {
 #' @param roi_dimensions Data frame from \code{\link{read_roi_dimensions}}
 #' @param use_threshold Logical, whether to use threshold-based classification
 #'   (TBclass_above_threshold) or raw predictions (TBclass)
-#' @return Data frame with columns: file_name, class_name, score, roi_area
+#' @return Data frame with columns: file_name, class_name, score, width, height, roi_area
 #' @export
 #' @examples
 #' \dontrun{
@@ -136,17 +149,25 @@ load_from_classifier_mat <- function(mat_path, sample_name, class2use, roi_dimen
   # Handle any NA values
   class_names[is.na(class_names)] <- "unclassified"
 
-  # Match ROI dimensions
-  roi_areas <- sapply(roi_numbers, function(rn) {
+  # Match ROI dimensions - extracting width, height, and area
+  roi_data <- lapply(roi_numbers, function(rn) {
     idx <- which(roi_dimensions$roi_number == rn)
-    if (length(idx) > 0) roi_dimensions$area[idx] else 1
+    if (length(idx) > 0) {
+      list(width = roi_dimensions$width[idx],
+           height = roi_dimensions$height[idx],
+           area = roi_dimensions$area[idx])
+    } else {
+      list(width = 1, height = 1, area = 1)
+    }
   })
 
   classifications <- data.frame(
     file_name = sprintf("%s_%05d.png", sample_name, roi_numbers),
     class_name = class_names,
     score = NA_real_,
-    roi_area = roi_areas,
+    width = sapply(roi_data, `[[`, "width"),
+    height = sapply(roi_data, `[[`, "height"),
+    roi_area = sapply(roi_data, `[[`, "area"),
     stringsAsFactors = FALSE
   )
 
@@ -161,7 +182,7 @@ load_from_classifier_mat <- function(mat_path, sample_name, class2use, roi_dimen
 #'
 #' @param sample_name Sample name (e.g., "D20230101T120000_IFCB134")
 #' @param roi_dimensions Data frame from \code{\link{read_roi_dimensions}}
-#' @return Data frame with columns: file_name, class_name, score, roi_area
+#' @return Data frame with columns: file_name, class_name, score, width, height, roi_area
 #' @export
 #' @examples
 #' # Create mock ROI dimensions
@@ -183,6 +204,8 @@ create_new_classifications <- function(sample_name, roi_dimensions) {
     file_name = sprintf("%s_%05d.png", sample_name, roi_dimensions$roi_number),
     class_name = "unclassified",
     score = NA_real_,
+    width = roi_dimensions$width,
+    height = roi_dimensions$height,
     roi_area = roi_dimensions$area,
     stringsAsFactors = FALSE
   )

--- a/R/sample_loading.R
+++ b/R/sample_loading.R
@@ -95,13 +95,25 @@ load_from_mat <- function(mat_path, sample_name, class2use, roi_dimensions) {
     return(class2use[idx])
   })
 
+  # Match ROI dimensions by roi_number (safe lookup with NA fallback)
+  roi_data <- lapply(roi_numbers, function(rn) {
+    idx <- which(roi_dimensions$roi_number == rn)
+    if (length(idx) > 0) {
+      list(width = roi_dimensions$width[idx],
+           height = roi_dimensions$height[idx],
+           area = roi_dimensions$area[idx])
+    } else {
+      list(width = NA_real_, height = NA_real_, area = NA_real_)
+    }
+  })
+
   classifications <- data.frame(
     file_name = sprintf("%s_%05d.png", sample_name, roi_numbers),
     class_name = class_names,
     score = NA_real_,
-    width = roi_dimensions$width[roi_numbers],
-    height = roi_dimensions$height[roi_numbers],
-    roi_area = roi_dimensions$area[roi_numbers],
+    width = vapply(roi_data, `[[`, numeric(1), "width"),
+    height = vapply(roi_data, `[[`, numeric(1), "height"),
+    roi_area = vapply(roi_data, `[[`, numeric(1), "area"),
     stringsAsFactors = FALSE
   )
 
@@ -157,7 +169,7 @@ load_from_classifier_mat <- function(mat_path, sample_name, class2use, roi_dimen
            height = roi_dimensions$height[idx],
            area = roi_dimensions$area[idx])
     } else {
-      list(width = 1, height = 1, area = 1)
+      list(width = NA_real_, height = NA_real_, area = NA_real_)
     }
   })
 
@@ -165,9 +177,9 @@ load_from_classifier_mat <- function(mat_path, sample_name, class2use, roi_dimen
     file_name = sprintf("%s_%05d.png", sample_name, roi_numbers),
     class_name = class_names,
     score = NA_real_,
-    width = sapply(roi_data, `[[`, "width"),
-    height = sapply(roi_data, `[[`, "height"),
-    roi_area = sapply(roi_data, `[[`, "area"),
+    width = vapply(roi_data, `[[`, numeric(1), "width"),
+    height = vapply(roi_data, `[[`, numeric(1), "height"),
+    roi_area = vapply(roi_data, `[[`, numeric(1), "area"),
     stringsAsFactors = FALSE
   )
 

--- a/man/create_new_classifications.Rd
+++ b/man/create_new_classifications.Rd
@@ -12,7 +12,7 @@ create_new_classifications(sample_name, roi_dimensions)
 \item{roi_dimensions}{Data frame from \code{\link{read_roi_dimensions}}}
 }
 \value{
-Data frame with columns: file_name, class_name, score, roi_area
+Data frame with columns: file_name, class_name, score, width, height, roi_area
 }
 \description{
 Creates a classifications data frame with all ROIs set to "unclassified",

--- a/man/load_from_classifier_mat.Rd
+++ b/man/load_from_classifier_mat.Rd
@@ -25,7 +25,7 @@ load_from_classifier_mat(
 (TBclass_above_threshold) or raw predictions (TBclass)}
 }
 \value{
-Data frame with columns: file_name, class_name, score, roi_area
+Data frame with columns: file_name, class_name, score, width, height, roi_area
 }
 \description{
 Reads a MATLAB classifier output file (from ifcb-analysis random forest

--- a/man/load_from_mat.Rd
+++ b/man/load_from_mat.Rd
@@ -16,7 +16,7 @@ load_from_mat(mat_path, sample_name, class2use, roi_dimensions)
 \item{roi_dimensions}{Data frame from \code{\link{read_roi_dimensions}}}
 }
 \value{
-Data frame with columns: file_name, class_name, score, roi_area
+Data frame with columns: file_name, class_name, score, width, height, roi_area
 }
 \description{
 Reads a MATLAB annotation file (created by ClassiPyR or ifcb-analysis)

--- a/tests/testthat/test-sample_loading.R
+++ b/tests/testthat/test-sample_loading.R
@@ -142,7 +142,7 @@ test_that("load_from_mat reads manual annotation file correctly", {
 
   expect_s3_class(classifications, "data.frame")
   expect_true(nrow(classifications) > 0)
-  expect_named(classifications, c("file_name", "class_name", "score", "roi_area"))
+  expect_named(classifications, c("file_name", "class_name", "score", "width", "height", "roi_area"))
   # All file names should contain sample name and .png
   expect_true(all(grepl(sample_name, classifications$file_name)))
   expect_true(all(grepl("\\.png$", classifications$file_name)))
@@ -182,7 +182,7 @@ test_that("load_from_classifier_mat reads classifier output correctly", {
 
   expect_s3_class(classifications, "data.frame")
   expect_true(nrow(classifications) > 0)
-  expect_named(classifications, c("file_name", "class_name", "score", "roi_area"))
+  expect_named(classifications, c("file_name", "class_name", "score", "width", "height", "roi_area"))
   # Class names should be strings
   expect_type(classifications$class_name, "character")
   # Should be sorted by area descending


### PR DESCRIPTION
Features:
- Sort unclassified images by ROI area (largest first) in annotation mode This groups similar-sized organisms together for faster annotation
- Add width, height columns to classifications data frame for size-based sorting

Bug fixes:
- Fix sample dropdown not updating status symbol (pencil) after saving Use JavaScript to update display text without rebuilding entire dropdown
- Only update sample status when changes are actually saved Previously status changed even when switching from unchanged samples
- Fix incorrect image count in loading notifications Now shows count after filtering empty triggers, not before

Files changed:
- R/sample_loading.R: Add width/height columns to all loading functions
- R/server.R:
  - Add pending_sample_select to reactiveValues
  - Add update_current_sample_status() helper using JavaScript
  - Modify filtered_images() reactive for size-based sorting in annotation mode
  - Capture save_sample_annotations() return value before updating status
  - Move loading notification to after empty trigger filtering
  - Add mode_message parameter to extract_sample_images()