### PR TITLE
ci: fix codecov upload after action v7 bump

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
-          file: ./cobertura.xml
+          files: ./cobertura.xml
           plugin: noop
           disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
The `codecov/codecov-action` bump from v4 → v7 (#31) broke the test-coverage workflow on `main`.

codecov-action **v5** removed the singular `file:` input in favor of plural `files:`. Combined with `disable_search: true`, the upload found no coverage report, and since pushes to `main` set `fail_ci_if_error: true`, the job failed.

## Fix
`file: ./cobertura.xml` → `files: ./cobertura.xml`

## Test plan
- [x] CI test-coverage workflow passes on this branch / after merge to main